### PR TITLE
don't delete the handler in loseConnection

### DIFF
--- a/test_websocket.py
+++ b/test_websocket.py
@@ -500,3 +500,14 @@ class WebSocketHandlerTestCase(TestCase):
         """
         self.request.connectionLost(Failure(CONNECTION_DONE))
         self.handler.lostReason.trap(ConnectionDone)
+
+    def test_loseConnection_and_connectionLost(self):
+        """
+        L{Request.connectionLost} called after
+        L{WebSocketTransport.loseConnection} does not cause problems.
+        """
+        self.handler.transport.loseConnection()
+        # loseConnection() on the transport will disconnect the request, and it
+        # will get its connectionLost method fired
+        self.request.connectionLost(Failure(CONNECTION_DONE))
+        self.assertTrue(self.channel.transport.disconnected)

--- a/websocket.py
+++ b/websocket.py
@@ -367,9 +367,6 @@ class WebSocketTransport(object):
         Close the connection.
         """
         self._request.transport.loseConnection()
-        del self._request.transport
-        del self._request
-        del self._handler
 
 class WebSocketHandler(object):
     """


### PR DESCRIPTION
if you call loseConnection on the WebSocketTransport it passes it on to the underlying Request, which then errbacks the notifications obtained with notifyFinish(), and WebSocketTransport then gets connectionLost on itself... and tries to call self._handler.connectionLost(), but the handler is already deleted.

I think you don't have to delete the handler in loseConnection, because connectionLost is going to be called anyway, so you can do it there.
