### PR TITLE
Support 0xFF frames and closing handshakes

### DIFF
--- a/test_websocket.py
+++ b/test_websocket.py
@@ -519,12 +519,12 @@ class WebSocketFrameDecoderTestCase(TestCase):
         self.assertFalse(self.channel.transport.disconnected)
 
 
-    def text_maxBinaryLength(self):
+    def test_maxBinaryLength(self):
         """
         If a binary frame's declared length exceeds MAX_BINARY_LENGTH, the
         connection is dropped.
         """
-        self.decoder.dataReceived("\xff\xff\xff\xff\xff\xff")
+        self.decoder.dataReceived("\xff\xff\xff\xff\xff\x01")
         self.assertTrue(self.channel.transport.disconnected)
 
 

--- a/test_websocket.py
+++ b/test_websocket.py
@@ -528,6 +528,17 @@ class WebSocketFrameDecoderTestCase(TestCase):
         self.assertTrue(self.channel.transport.disconnected)
 
 
+    def test_closingHandshake(self):
+        """
+        After receiving the closing handshake, the server sends its own closing
+        handshake and ignores all future data.
+        """
+        self.decoder.dataReceived("\x00frame\xff\xff\x00random crap")
+        self.decoder.dataReceived("more random crap, that's discarded")
+        self.assertEquals(self.decoder.handler.frames, ["frame"])
+        self.assertTrue(self.decoder.closing)
+
+
     def test_invalidFrameType(self):
         """
         Frame types other than 0x00 and 0xff cause the connection to be

--- a/test_websocket.py
+++ b/test_websocket.py
@@ -11,6 +11,7 @@ from twisted.python.failure import Failure
 
 from websocket import WebSocketHandler, WebSocketFrameDecoder
 from websocket import WebSocketSite, WebSocketTransport
+from websocket import DecodingError
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request, Site
@@ -372,6 +373,17 @@ class WebSocketFrameDecoderTestCase(TestCase):
         transport._attachHandler(handler)
         self.decoder = WebSocketFrameDecoder(request, handler)
         self.decoder.MAX_LENGTH = 100
+        self.decoder.MAX_BINARY_LENGTH = 1000
+
+
+    def assertOneDecodingError(self):
+        """
+        Assert that exactly one L{DecodingError} has been logged and return
+        that error.
+        """
+        errors = self.flushLoggedErrors(DecodingError)
+        self.assertEquals(len(errors), 1)
+        return errors[0]
 
 
     def test_oneFrame(self):
@@ -406,6 +418,7 @@ class WebSocketFrameDecoderTestCase(TestCase):
         dropped.
         """
         self.decoder.dataReceived("frame\xff")
+        self.assertOneDecodingError()
         self.assertTrue(self.channel.transport.disconnected)
 
 
@@ -415,6 +428,7 @@ class WebSocketFrameDecoderTestCase(TestCase):
         frame, the connection is dropped.
         """
         self.decoder.dataReceived("\x00frame\xfffoo")
+        self.assertOneDecodingError()
         self.assertTrue(self.channel.transport.disconnected)
         self.assertEquals(self.decoder.handler.frames, ["frame"])
 
@@ -455,6 +469,86 @@ class WebSocketFrameDecoderTestCase(TestCase):
             self.decoder.dataReceived("\x00" + "x" * 10 + "\xff")
         self.assertFalse(self.channel.transport.disconnected)
 
+
+    def test_oneBinaryFrame(self):
+        """
+        A binary frame is parsed and ignored, the following text frame is
+        delivered.
+        """
+        self.decoder.dataReceived("\xff\x0abinarydata\x00text frame\xff")
+        self.assertEquals(self.decoder.handler.frames, ["text frame"])
+
+
+    def test_multipleBinaryFrames(self):
+        """
+        Text frames intermingled with binary frames are parsed correctly.
+        """
+        tf1, tf2, tf3 = "\x00frame1\xff", "\x00frame2\xff", "\x00frame3\xff"
+        bf1, bf2, bf3 = "\xff\x01X", "\xff\x1a" + "X" * 0x1a, "\xff\x02AB"
+
+        self.decoder.dataReceived(tf1 + bf1 + bf2 + tf2 + tf3 + bf3)
+        self.assertEquals(self.decoder.handler.frames,
+                          ["frame1", "frame2", "frame3"])
+
+
+    def test_binaryFrameMultipleLengthBytes(self):
+        """
+        A binary frame can have its length field spread across multiple bytes.
+        """
+        bf = "\xff\x81\x48" + "X" * 200
+        tf = "\x00frame\xff"
+        self.decoder.dataReceived(bf + tf + bf)
+        self.assertEquals(self.decoder.handler.frames, ["frame"])
+
+
+    def test_binaryAndTextSplitted(self):
+        """
+        Intermingled binary and text frames can be split across several
+        C{dataReceived} calls.
+        """
+        tf1, tf2 = "\x00text\xff", "\x00other text\xff"
+        bf1, bf2, bf3 = ("\xff\x01X", "\xff\x81\x48" + "X" * 200,
+                         "\xff\x20" + "X" * 32)
+
+        chunks = [bf1[0], bf1[1:], tf1[:2], tf1[2:] + bf2[:2], bf2[2:-2],
+                  bf2[-2:-1], bf2[1] + tf2[:-1], tf2[-1], bf3]
+        for c in chunks:
+            self.decoder.dataReceived(c)
+
+        self.assertEquals(self.decoder.handler.frames, ["text", "other text"])
+        self.assertFalse(self.channel.transport.disconnected)
+
+
+    def text_maxBinaryLength(self):
+        """
+        If a binary frame's declared length exceeds MAX_BINARY_LENGTH, the
+        connection is dropped.
+        """
+        self.decoder.dataReceived("\xff\xff\xff\xff\xff\xff")
+        self.assertTrue(self.channel.transport.disconnected)
+
+
+    def test_invalidFrameType(self):
+        """
+        Frame types other than 0x00 and 0xff cause the connection to be
+        dropped.
+        """
+        ok = "\x00ok\xff"
+        wrong = "\x05foo\xff"
+
+        self.decoder.dataReceived(ok + wrong + ok)
+        self.assertEquals(self.decoder.handler.frames, ["ok"])
+        error = self.assertOneDecodingError()
+        self.assertTrue(self.channel.transport.disconnected)
+
+
+    def test_emptyFrame(self):
+        """
+        An empty text frame is correctly parsed.
+        """
+        self.decoder.dataReceived("\x00\xff")
+        self.assertEquals(self.decoder.handler.frames, [""])
+        self.assertFalse(self.channel.transport.disconnected)
 
 
 class WebSocketHandlerTestCase(TestCase):

--- a/websocket.py
+++ b/websocket.py
@@ -549,12 +549,13 @@ class WebSocketFrameDecoder(object):
 
             self._currentFrameLength *= 128
             self._currentFrameLength += length
-            if self._currentFrameLength > self.MAX_BINARY_LENGTH:
-                self.handler.frameLengthExceeded()
 
             current += 1
 
             if not more:
+                if self._currentFrameLength > self.MAX_BINARY_LENGTH:
+                    self.handler.frameLengthExceeded()
+
                 remainingData = data[current:]
                 self._addRemainingData(remainingData)
                 self._state = "PARSING_BINARY_FRAME"

--- a/websocket.py
+++ b/websocket.py
@@ -18,6 +18,8 @@ from hashlib import md5
 import struct
 
 from twisted.internet import interfaces
+from twisted.python import log
+from twisted.web._newclient import makeStatefulDispatcher
 from twisted.web.http import datetimeToString
 from twisted.web.http import _IdentityTransferDecoder
 from twisted.web.server import Request, Site, version, unquote
@@ -417,15 +419,28 @@ class WebSocketHandler(object):
         """
 
 
+class IncompleteFrame(Exception):
+    """
+    Not enough data to complete a WebSocket frame.
+    """
+
+
+class DecodingError(Exception):
+    """
+    The incoming data is not valid WebSocket protocol data.
+    """
+
 
 class WebSocketFrameDecoder(object):
     """
     Decode WebSocket frames and pass them to the attached C{WebSocketHandler}
     instance.
 
-    @ivar MAX_LENGTH: maximum len of the frame allowed, before calling
+    @ivar MAX_LENGTH: maximum len of a text frame allowed, before calling
         C{frameLengthExceeded} on the handler.
     @type MAX_LENGTH: C{int}
+    @ivar MAX_BINARY_LENGTH: like C{MAX_LENGTH}, but for 0xff type frames
+    @type MAX_BINARY_LENGTH: C{int}
     @ivar request: C{Request} instance.
     @type request: L{twisted.web.server.Request}
     @ivar handler: L{WebSocketHandler} instance handling the request.
@@ -438,13 +453,14 @@ class WebSocketFrameDecoder(object):
     """
 
     MAX_LENGTH = 16384
-
+    MAX_BINARY_LENGTH = 2147483648
 
     def __init__(self, request, handler):
         self.request = request
         self.handler = handler
         self._data = []
         self._currentFrameLength = 0
+        self._state = "FRAME_START"
 
     def dataReceived(self, data):
         """
@@ -455,35 +471,105 @@ class WebSocketFrameDecoder(object):
         """
         if not data:
             return
-        while True:
-            endIndex = data.find("\xff")
-            if endIndex != -1:
-                self._currentFrameLength += endIndex
-                if self._currentFrameLength > self.MAX_LENGTH:
-                    self.handler.frameLengthExceeded()
-                    break
-                self._currentFrameLength = 0
-                frame = "".join(self._data) + data[:endIndex]
-                self._data[:] = []
-                if frame[0] != "\x00":
-                    self.request.transport.loseConnection()
-                    break
-                self.handler.frameReceived(frame[1:])
-                data = data[endIndex + 1:]
-                if not data:
-                    break
-                if data[0] != "\x00":
-                    self.request.transport.loseConnection()
-                    break
-            else:
-                self._currentFrameLength += len(data)
-                if self._currentFrameLength > self.MAX_LENGTH + 1:
-                    self.handler.frameLengthExceeded()
-                else:
-                    self._data.append(data)
+        self._data.append(data)
+
+        while self._data:
+            try:
+                self.consumeData(self._data[-1])
+            except IncompleteFrame:
+                break
+            except DecodingError:
+                log.err()
+                self.request.transport.loseConnection()
                 break
 
+    def consumeData(self, data):
+        """
+        Process the last data chunk received.
+
+        After processing is done, L{IncompleteFrame} should be raised or
+        L{_addRemainingData} should be called.
+
+        @param data: last chunk of data received.
+        @type data: C{str}
+        """
+    consumeData = makeStatefulDispatcher("consumeData", consumeData)
+
+    def _consumeData_FRAME_START(self, data):
+        self._currentFrameLength = 0
+
+        if data[0] == "\x00":
+            self._state = "PARSING_TEXT_FRAME"
+        elif data[0] == "\xff":
+            self._state = "PARSING_LENGTH"
+        else:
+            raise DecodingError("Invalid frame type 0x%s" %
+                                data[0].encode("hex"))
+
+        self._addRemainingData(data[1:])
+
+    def _consumeData_PARSING_TEXT_FRAME(self, data):
+        endIndex = data.find("\xff")
+        if endIndex == -1:
+            self._currentFrameLength += len(data)
+        else:
+            self._currentFrameLength += endIndex
+
+        self._currentFrameLength += endIndex
+        # check length + 1 to account for the initial frame type byte
+        if self._currentFrameLength + 1 > self.MAX_LENGTH:
+            self.handler.frameLengthExceeded()
+
+        if endIndex == -1:
+            raise IncompleteFrame()
+
+        frame = "".join(self._data[:-1]) + data[:endIndex]
+        self.handler.frameReceived(frame)
+
+        remainingData = data[endIndex + 1:]
+        self._addRemainingData(remainingData)
+
+        self._state = "FRAME_START"
+
+    def _consumeData_PARSING_LENGTH(self, data):
+        current = 0
+        available = len(data)
+
+        while current < available:
+            byte = ord(data[current])
+            length, more = byte & 0x7F, bool(byte & 0x80)
+
+            self._currentFrameLength *= 128
+            self._currentFrameLength += length
+            if self._currentFrameLength > self.MAX_BINARY_LENGTH:
+                self.handler.frameLengthExceeded()
+
+            current += 1
+
+            if not more:
+                remainingData = data[current:]
+                self._addRemainingData(remainingData)
+                self._state = "PARSING_BINARY_FRAME"
+                break
+        else:
+            raise IncompleteFrame()
+
+    def _consumeData_PARSING_BINARY_FRAME(self, data):
+        available = len(data)
+
+        if self._currentFrameLength <= available:
+            remainingData = data[self._currentFrameLength:]
+            self._addRemainingData(remainingData)
+            self._state = "FRAME_START"
+        else:
+            self._currentFrameLength -= available
+            self._data[:] = []
+
+    def _addRemainingData(self, remainingData):
+        if remainingData:
+            self._data[:] = [remainingData]
+        else:
+            self._data[:] = []
 
 
 __all__ = ["WebSocketHandler", "WebSocketSite"]
-


### PR DESCRIPTION
As specified in http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76#section-4.2 WebSocket frames can also be of type 0xFF, with a length specification followed by arbitrary data, that the server should discard. The first commit implements parsing this type of frames. The parsing process has been overhauled by using twisted.web._newclient.makeStatefulDispatch, so it introduces a dependency on Twisted 9.0.0 (I hope it's OK, if not it's easy to do the dispatch by hand).

The second commit implements the closing handshake that can be initiated by the client, as described in http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76#section-1.4. Without this, closing the browser while it's connected to the WebSocket server results in a traceback in the server log (this happens both with Chrome and Firefox native WebSockets and with web-socket-js).
