### PR TITLE
Support the hybi-10 version of the WebSocket protocol

### DIFF
--- a/test_websocket.py
+++ b/test_websocket.py
@@ -519,12 +519,12 @@ class WebSocketFrameDecoderTestCase(TestCase):
         self.assertFalse(self.channel.transport.disconnected)
 
 
-    def text_maxBinaryLength(self):
+    def test_maxBinaryLength(self):
         """
         If a binary frame's declared length exceeds MAX_BINARY_LENGTH, the
         connection is dropped.
         """
-        self.decoder.dataReceived("\xff\xff\xff\xff\xff\xff")
+        self.decoder.dataReceived("\xff\xff\xff\xff\xff\x01")
         self.assertTrue(self.channel.transport.disconnected)
 
 

--- a/test_websocket.py
+++ b/test_websocket.py
@@ -528,6 +528,17 @@ class WebSocketFrameDecoderTestCase(TestCase):
         self.assertTrue(self.channel.transport.disconnected)
 
 
+    def test_closingHandshake(self):
+        """
+        After receiving the closing handshake, the server sends its own closing
+        handshake and ignores all future data.
+        """
+        self.decoder.dataReceived("\x00frame\xff\xff\x00random crap")
+        self.decoder.dataReceived("more random crap, that's discarded")
+        self.assertEquals(self.decoder.handler.frames, ["frame"])
+        self.assertTrue(self.decoder.closing)
+
+
     def test_invalidFrameType(self):
         """
         Frame types other than 0x00 and 0xff cause the connection to be

--- a/test_websocket.py
+++ b/test_websocket.py
@@ -803,6 +803,8 @@ class WebSocketHybiFrameDecoderTestCase(TestCase):
         """
         self.decoder.dataReceived(self.hello + self.close + "crap" * 20)
         self.assertEquals(self.decoder.handler.frames, ["Hello"])
+        self.assertEquals(self.decoder.handler.closes,
+                          [(1000, "Normal Closure")])
 
         result = self.channel.transport.written.getvalue()
         headers, response = result.split('\r\n\r\n')

--- a/test_websocket.py
+++ b/test_websocket.py
@@ -11,6 +11,7 @@ from twisted.python.failure import Failure
 
 from websocket import WebSocketHandler, WebSocketFrameDecoder
 from websocket import WebSocketSite, WebSocketTransport
+from websocket import DecodingError
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request, Site
@@ -372,6 +373,17 @@ class WebSocketFrameDecoderTestCase(TestCase):
         transport._attachHandler(handler)
         self.decoder = WebSocketFrameDecoder(request, handler)
         self.decoder.MAX_LENGTH = 100
+        self.decoder.MAX_BINARY_LENGTH = 1000
+
+
+    def assertOneDecodingError(self):
+        """
+        Assert that exactly one L{DecodingError} has been logged and return
+        that error.
+        """
+        errors = self.flushLoggedErrors(DecodingError)
+        self.assertEquals(len(errors), 1)
+        return errors[0]
 
 
     def test_oneFrame(self):
@@ -406,6 +418,7 @@ class WebSocketFrameDecoderTestCase(TestCase):
         dropped.
         """
         self.decoder.dataReceived("frame\xff")
+        self.assertOneDecodingError()
         self.assertTrue(self.channel.transport.disconnected)
 
 
@@ -415,6 +428,7 @@ class WebSocketFrameDecoderTestCase(TestCase):
         frame, the connection is dropped.
         """
         self.decoder.dataReceived("\x00frame\xfffoo")
+        self.assertOneDecodingError()
         self.assertTrue(self.channel.transport.disconnected)
         self.assertEquals(self.decoder.handler.frames, ["frame"])
 
@@ -455,6 +469,86 @@ class WebSocketFrameDecoderTestCase(TestCase):
             self.decoder.dataReceived("\x00" + "x" * 10 + "\xff")
         self.assertFalse(self.channel.transport.disconnected)
 
+
+    def test_oneBinaryFrame(self):
+        """
+        A binary frame is parsed and ignored, the following text frame is
+        delivered.
+        """
+        self.decoder.dataReceived("\xff\x0abinarydata\x00text frame\xff")
+        self.assertEquals(self.decoder.handler.frames, ["text frame"])
+
+
+    def test_multipleBinaryFrames(self):
+        """
+        Text frames intermingled with binary frames are parsed correctly.
+        """
+        tf1, tf2, tf3 = "\x00frame1\xff", "\x00frame2\xff", "\x00frame3\xff"
+        bf1, bf2, bf3 = "\xff\x01X", "\xff\x1a" + "X" * 0x1a, "\xff\x02AB"
+
+        self.decoder.dataReceived(tf1 + bf1 + bf2 + tf2 + tf3 + bf3)
+        self.assertEquals(self.decoder.handler.frames,
+                          ["frame1", "frame2", "frame3"])
+
+
+    def test_binaryFrameMultipleLengthBytes(self):
+        """
+        A binary frame can have its length field spread across multiple bytes.
+        """
+        bf = "\xff\x81\x48" + "X" * 200
+        tf = "\x00frame\xff"
+        self.decoder.dataReceived(bf + tf + bf)
+        self.assertEquals(self.decoder.handler.frames, ["frame"])
+
+
+    def test_binaryAndTextSplitted(self):
+        """
+        Intermingled binary and text frames can be split across several
+        C{dataReceived} calls.
+        """
+        tf1, tf2 = "\x00text\xff", "\x00other text\xff"
+        bf1, bf2, bf3 = ("\xff\x01X", "\xff\x81\x48" + "X" * 200,
+                         "\xff\x20" + "X" * 32)
+
+        chunks = [bf1[0], bf1[1:], tf1[:2], tf1[2:] + bf2[:2], bf2[2:-2],
+                  bf2[-2:-1], bf2[1] + tf2[:-1], tf2[-1], bf3]
+        for c in chunks:
+            self.decoder.dataReceived(c)
+
+        self.assertEquals(self.decoder.handler.frames, ["text", "other text"])
+        self.assertFalse(self.channel.transport.disconnected)
+
+
+    def text_maxBinaryLength(self):
+        """
+        If a binary frame's declared length exceeds MAX_BINARY_LENGTH, the
+        connection is dropped.
+        """
+        self.decoder.dataReceived("\xff\xff\xff\xff\xff\xff")
+        self.assertTrue(self.channel.transport.disconnected)
+
+
+    def test_invalidFrameType(self):
+        """
+        Frame types other than 0x00 and 0xff cause the connection to be
+        dropped.
+        """
+        ok = "\x00ok\xff"
+        wrong = "\x05foo\xff"
+
+        self.decoder.dataReceived(ok + wrong + ok)
+        self.assertEquals(self.decoder.handler.frames, ["ok"])
+        error = self.assertOneDecodingError()
+        self.assertTrue(self.channel.transport.disconnected)
+
+
+    def test_emptyFrame(self):
+        """
+        An empty text frame is correctly parsed.
+        """
+        self.decoder.dataReceived("\x00\xff")
+        self.assertEquals(self.decoder.handler.frames, [""])
+        self.assertFalse(self.channel.transport.disconnected)
 
 
 class WebSocketHandlerTestCase(TestCase):

--- a/test_websocket.py
+++ b/test_websocket.py
@@ -4,14 +4,17 @@
 """
 Tests for L{twisted.web.websocket}.
 """
+import base64
+from hashlib import sha1
 
 from twisted.internet.main import CONNECTION_DONE
 from twisted.internet.error import ConnectionDone
 from twisted.python.failure import Failure
 
 from websocket import WebSocketHandler, WebSocketFrameDecoder
-from websocket import WebSocketSite, WebSocketTransport
-from websocket import DecodingError
+from websocket import WebSocketHybiFrameDecoder
+from websocket import WebSocketSite, WebSocketTransport, WebSocketHybiTransport
+from websocket import DecodingError, OPCODE_PING, OPCODE_TEXT
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request, Site
@@ -45,11 +48,26 @@ class TestHandler(WebSocketHandler):
     def __init__(self, request):
         WebSocketHandler.__init__(self, request)
         self.frames = []
+        self.binaryFrames = []
+        self.pongs = []
+        self.closes = []
         self.lostReason = None
 
 
     def frameReceived(self, frame):
         self.frames.append(frame)
+
+
+    def binaryFrameReceived(self, frame):
+        self.binaryFrames.append(frame)
+
+
+    def pongReceived(self, data):
+        self.pongs.append(data)
+
+
+    def closeReceived(self, code, msg):
+        self.closes.append((code, msg))
 
 
     def connectionLost(self, reason):
@@ -82,6 +100,8 @@ class WebSocketSiteTestCase(TestCase):
             channel.transport = channel.SSL()
         channel.site = self.site
         request = self.site.requestFactory(channel, queued)
+        # store the reference to the request, so the tests can access it
+        channel.request = request
         for k, v in headers:
             request.requestHeaders.addRawHeader(k, v)
         request.gotLength(0)
@@ -359,6 +379,91 @@ class WebSocketSiteTestCase(TestCase):
             ValueError, self.site.addHandler, "test", TestHandler)
 
 
+    def test_render_handShakeHybi(self):
+        """
+        Test a hybi-10 handshake.
+        """
+        # the key is a base64 encoded 16-bit integer, here chosen to be 14
+        key = "AA4="
+        headers = [
+            ("Upgrade", "websocket"), ("Connection", "Upgrade"),
+            ("Host", "localhost"), ("Origin", "http://localhost/"),
+            ("Sec-WebSocket-Version", "8"), ("Sec-WebSocket-Key", key)]
+        channel = self.renderRequest(headers=headers)
+
+        self.assertTrue(channel.raw)
+
+        result = channel.transport.written.getvalue()
+        headers, response = result.split('\r\n\r\n')
+
+        guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+        accept = base64.b64encode(sha1(key + guid).digest())
+        self.assertEquals(
+            headers,
+            "HTTP/1.1 101 Switching Protocols\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            "Sec-WebSocket-Accept: %s" % accept)
+
+        self.assertFalse(channel.transport.disconnected)
+        self.assertFalse(channel.request.finished)
+
+
+    def test_hybiWrongVersion(self):
+        """
+        A handshake that requests an unsupported version of the protocol
+        results in HTTP 426.
+        """
+        key = "AA4="
+        headers = [
+            ("Upgrade", "websocket"), ("Connection", "Upgrade"),
+            ("Host", "localhost"), ("Origin", "http://localhost/"),
+            ("Sec-WebSocket-Version", "9"), ("Sec-WebSocket-Key", key)]
+        channel = self.renderRequest(headers=headers)
+
+        result = channel.transport.written.getvalue()
+
+        self.assertIn("HTTP/1.1 426", result)
+        # Twisted canonicalizes header names (see
+        # http_headers.Headers._canonicalNameCaps), so it's not
+        # Sec-WebSocket-Version, but Sec-Websocket-Version, but clients
+        # understand it anyway
+        self.assertIn("Sec-Websocket-Version: 8", result)
+        self.assertTrue(channel.request.finished)
+
+
+    def test_hybiNoKey(self):
+        """
+        A handshake without a websocket key results in HTTP 400.
+        """
+        headers = [
+            ("Upgrade", "websocket"), ("Connection", "Upgrade"),
+            ("Host", "localhost"), ("Origin", "http://localhost/"),
+            ("Sec-WebSocket-Version", "8")]
+        channel = self.renderRequest(headers=headers)
+
+        result = channel.transport.written.getvalue()
+
+        self.assertIn("HTTP/1.1 400", result)
+        self.assertTrue(channel.request.finished)
+
+
+    def test_hybiNotFound(self):
+        """
+        A request for an unknown endpoint results in HTTP 404.
+        """
+        key = "AA4="
+        headers = [
+            ("Upgrade", "websocket"), ("Connection", "Upgrade"),
+            ("Host", "localhost"), ("Origin", "http://localhost/"),
+            ("Sec-WebSocket-Version", "8"), ("Sec-WebSocket-Key", key)]
+        channel = self.renderRequest(headers=headers, url="/foo")
+
+        result = channel.transport.written.getvalue()
+
+        self.assertIn("HTTP/1.1 404", result)
+        self.assertTrue(channel.request.finished)
+
 
 class WebSocketFrameDecoderTestCase(TestCase):
     """
@@ -562,6 +667,172 @@ class WebSocketFrameDecoderTestCase(TestCase):
         self.assertFalse(self.channel.transport.disconnected)
 
 
+class WebSocketHybiFrameDecoderTestCase(TestCase):
+    """
+    Test for C{WebSocketHybiFrameDecoder}.
+    """
+
+    def setUp(self):
+        self.channel = DummyChannel()
+        request = Request(self.channel, False)
+        transport = WebSocketHybiTransport(request)
+        handler = TestHandler(transport)
+        transport._attachHandler(handler)
+        self.decoder = WebSocketHybiFrameDecoder(request, handler)
+        self.decoder.MAX_LENGTH = 100
+        self.decoder.MAX_BINARY_LENGTH = 1000
+        # taken straight from the IETF draft, masking added where appropriate
+        self.hello = "\x81\x85\x37\xfa\x21\x3d\x7f\x9f\x4d\x51\x58"
+        self.frag_hello = ("\x01\x83\x12\x21\x65\x23\x5a\x44\x09",
+                           "\x80\x82\x63\x34\xf1\x00\x0f\x5b")
+        self.binary_orig = "\x3f" * 256
+        self.binary = ("\x82\xfe\x01\x00\x12\x6d\xa6\x23" +
+                       "\x2d\x52\x99\x1c" * 64)
+        self.ping = "\x89\x85\x56\x23\x88\x23\x1e\x46\xe4\x4f\x39"
+        self.pong = "\x8a\x85\xde\x41\x0f\x34\x96\x24\x63\x58\xb1"
+        self.pong_unmasked = "\x8a\x05\x48\x65\x6c\x6c\x6f"
+        # code 1000, message "Normal Closure"
+        self.close = ("\x88\x90\x34\x23\x87\xde\x37\xcb\xc9\xb1\x46"
+                      "\x4e\xe6\xb2\x14\x60\xeb\xb1\x47\x56\xf5\xbb")
+        self.empty_unmasked_close = "\x88\x00"
+        self.empty_text = "\x81\x80\x00\x01\x02\x03"
+        self.cont_empty_text = "\x00\x80\x00\x01\x02\x03"
+
+
+    def assertOneDecodingError(self):
+        """
+        Assert that exactly one L{DecodingError} has been logged and return
+        that error.
+        """
+        errors = self.flushLoggedErrors(DecodingError)
+        self.assertEquals(len(errors), 1)
+        return errors[0]
+
+
+    def test_oneTextFrame(self):
+        """
+        We can send one frame handled with one C{dataReceived} call.
+        """
+        self.decoder.dataReceived(self.hello)
+        self.assertEquals(self.decoder.handler.frames, ["Hello"])
+
+
+    def test_chunkedTextFrame(self):
+        """
+        We can send one text frame handled with multiple C{dataReceived} calls.
+        """
+        # taken straight from the IETF draft
+        for part in (self.hello[:1], self.hello[1:3],
+                     self.hello[3:7], self.hello[7:]):
+            self.decoder.dataReceived(part)
+        self.assertEquals(self.decoder.handler.frames, ["Hello"])
+
+
+    def test_fragmentedTextFrame(self):
+        """
+        We can send a fragmented frame handled with one C{dataReceived} call.
+        """
+        self.decoder.dataReceived("".join(self.frag_hello))
+        self.assertEquals(self.decoder.handler.frames, ["Hello"])
+
+
+    def test_chunkedfragmentedTextFrame(self):
+        """
+        We can send a fragmented text frame handled with multiple
+        C{dataReceived} calls.
+        """
+        # taken straight from the IETF draft
+        for part in (self.frag_hello[0][:3], self.frag_hello[0][3:]):
+            self.decoder.dataReceived(part)
+        for part in (self.frag_hello[1][:1], self.frag_hello[1][1:]):
+            self.decoder.dataReceived(part)
+        self.assertEquals(self.decoder.handler.frames, ["Hello"])
+
+
+    def test_twoFrames(self):
+        """
+        We can send two frames together and they will be correctly parsed.
+        """
+        self.decoder.dataReceived("".join(self.frag_hello) + self.hello)
+        self.assertEquals(self.decoder.handler.frames, ["Hello"] * 2)
+
+
+    def test_controlInterleaved(self):
+        """
+        A control message (in this case a pong) can appear between the
+        fragmented frames.
+        """
+        data = self.frag_hello[0] + self.pong + self.frag_hello[1]
+        for part in data[:2], data[2:7], data[7:8], data[8:14], data[14:]:
+            self.decoder.dataReceived(part)
+        self.assertEquals(self.decoder.handler.frames, ["Hello"])
+        self.assertEquals(self.decoder.handler.pongs, ["Hello"])
+
+
+    def test_binaryFrame(self):
+        """
+        We can send a binary frame that uses a longer length field.
+        """
+        data = self.binary
+        for part in data[:3], data[3:4], data[4:]:
+            self.decoder.dataReceived(part)
+        self.assertEquals(self.decoder.handler.binaryFrames,
+                          [self.binary_orig])
+
+
+    def test_pingInterleaved(self):
+        """
+        We can get a ping frame in the middle of a fragmented frame and we'll
+        correctly send a pong resonse.
+        """
+        data = self.frag_hello[0] + self.ping + self.frag_hello[1]
+        for part in data[:12], data[12:16], data[16:]:
+            self.decoder.dataReceived(part)
+        self.assertEquals(self.decoder.handler.frames, ["Hello"])
+
+        result = self.channel.transport.written.getvalue()
+        headers, response = result.split('\r\n\r\n')
+
+        self.assertEquals(response, self.pong_unmasked)
+
+
+    def test_close(self):
+        """
+        A close frame causes the remaining data to be discarded and the
+        connection to be closed.
+        """
+        self.decoder.dataReceived(self.hello + self.close + "crap" * 20)
+        self.assertEquals(self.decoder.handler.frames, ["Hello"])
+
+        result = self.channel.transport.written.getvalue()
+        headers, response = result.split('\r\n\r\n')
+
+        self.assertEquals(response, self.empty_unmasked_close)
+        self.assertTrue(self.channel.transport.disconnected)
+
+
+    def test_emptyFrame(self):
+        """
+        An empty text frame is correctly parsed.
+        """
+        self.decoder.dataReceived(self.empty_text)
+        self.assertEquals(self.decoder.handler.frames, [""])
+
+
+    def test_emptyFrameInterleaved(self):
+        """
+        An empty fragmented frame and a interleaved pong message are received
+        and parsed.
+        """
+        data = (self.frag_hello[0] + self.cont_empty_text +
+                self.pong + self.frag_hello[1])
+        for part in data[:1], data[1:8], data[8:17], data[17:]:
+            self.decoder.dataReceived(part)
+
+        self.assertEquals(self.decoder.handler.frames, ["Hello"])
+        self.assertEquals(self.decoder.handler.pongs, ["Hello"])
+
+
 class WebSocketHandlerTestCase(TestCase):
     """
     Tests for L{WebSocketHandler}.
@@ -605,3 +876,66 @@ class WebSocketHandlerTestCase(TestCase):
         """
         self.request.connectionLost(Failure(CONNECTION_DONE))
         self.handler.lostReason.trap(ConnectionDone)
+
+
+class WebSocketHybiHandlerTestCase(TestCase):
+    """
+    Tests for L{WebSocketHandler} using the hybi-10 protocol.
+    """
+
+    def setUp(self):
+        self.channel = DummyChannel()
+        self.request = request = Request(self.channel, False)
+        # Simulate request handling
+        request.startedWriting = True
+        transport = WebSocketHybiTransport(request)
+        self.handler = TestHandler(transport)
+        transport._attachHandler(self.handler)
+
+
+    def test_write(self):
+        """
+        L{WebSocketHybiTransport.write} wraps the data in a text frame and
+        writes it to the request.
+        """
+        self.handler.transport.write("Hello")
+        self.handler.transport.write("World")
+        self.assertEquals(
+            self.channel.transport.written.getvalue(),
+            "\x81\x05\x48\x65\x6c\x6c\x6f" + "\x81\x05\x57\x6f\x72\x6c\x64")
+        self.assertFalse(self.channel.transport.disconnected)
+
+
+    def test_sendFrame(self):
+        """
+        L{WebSocketHybiTransport.sendFrame} creates an unmasked hybi-10 frame
+        and writes it to the request
+        """
+        self.handler.transport.sendFrame(OPCODE_PING, "ping")
+        self.assertEquals(
+            self.channel.transport.written.getvalue(),
+            "\x89\x04\x70\x69\x6e\x67")
+        self.assertFalse(self.channel.transport.disconnected)
+
+
+    def test_sendLongFrame(self):
+        """
+        Sending a frame with a payload longer than 125 bytes results in a
+        longer length field written to the request.
+        """
+        self.handler.transport.sendFrame(OPCODE_TEXT, "crap" * 20000)
+        self.assertEquals(
+            self.channel.transport.written.getvalue(),
+            "\x81\x7f\x00\x00\x00\x00\x00\x01\x38\x80" + "crap" * 20000)
+        self.assertFalse(self.channel.transport.disconnected)
+
+
+    def test_sendFragmentedFrame(self):
+        """
+        Sending a frame with the fragmented flag makes the correct flag unset.
+        """
+        self.handler.transport.sendFrame(OPCODE_TEXT, "Hello", fragmented=True)
+        self.assertEquals(
+            self.channel.transport.written.getvalue(),
+            "\x01\x05\x48\x65\x6c\x6c\x6f")
+        self.assertFalse(self.channel.transport.disconnected)

--- a/websocket.py
+++ b/websocket.py
@@ -921,7 +921,7 @@ class WebSocketHybiFrameDecoder(WebSocketFrameDecoder):
                 self.handler.frameLengthExceeded()
             self.handler.binaryFrameReceived(frame)
         elif self._opcode == OPCODE_PING:
-            self.transport.sendFrame(OPCODE_PONG, frame)
+            self.handler.transport.sendFrame(OPCODE_PONG, frame)
         elif self._opcode == OPCODE_PONG:
             self.handler.pongReceived(frame)
 
@@ -945,11 +945,11 @@ class WebSocketHybiFrameDecoder(WebSocketFrameDecoder):
         self.handler.closeReceived(code, msg)
 
         # send the closing handshake
-        self.transport.sendFrame(OPCODE_CLOSE, "")
+        self.handler.transport.sendFrame(OPCODE_CLOSE, "")
 
         # discard all buffered data and lose connection
         self._data[:] = []
-        self.transport.loseConnection()
+        self.handler.transport.loseConnection()
 
 
 __all__ = ["WebSocketHandler", "WebSocketSite"]

--- a/websocket.py
+++ b/websocket.py
@@ -549,12 +549,13 @@ class WebSocketFrameDecoder(object):
 
             self._currentFrameLength *= 128
             self._currentFrameLength += length
-            if self._currentFrameLength > self.MAX_BINARY_LENGTH:
-                self.handler.frameLengthExceeded()
 
             current += 1
 
             if not more:
+                if self._currentFrameLength > self.MAX_BINARY_LENGTH:
+                    self.handler.frameLengthExceeded()
+
                 remainingData = data[current:]
                 self._addRemainingData(remainingData)
                 self._state = "PARSING_BINARY_FRAME"

--- a/websocket.py
+++ b/websocket.py
@@ -18,6 +18,8 @@ from hashlib import md5
 import struct
 
 from twisted.internet import interfaces
+from twisted.python import log
+from twisted.web._newclient import makeStatefulDispatcher
 from twisted.web.http import datetimeToString
 from twisted.web.http import _IdentityTransferDecoder
 from twisted.web.server import Request, Site, version, unquote
@@ -417,15 +419,28 @@ class WebSocketHandler(object):
         """
 
 
+class IncompleteFrame(Exception):
+    """
+    Not enough data to complete a WebSocket frame.
+    """
+
+
+class DecodingError(Exception):
+    """
+    The incoming data is not valid WebSocket protocol data.
+    """
+
 
 class WebSocketFrameDecoder(object):
     """
     Decode WebSocket frames and pass them to the attached C{WebSocketHandler}
     instance.
 
-    @ivar MAX_LENGTH: maximum len of the frame allowed, before calling
+    @ivar MAX_LENGTH: maximum len of a text frame allowed, before calling
         C{frameLengthExceeded} on the handler.
     @type MAX_LENGTH: C{int}
+    @ivar MAX_BINARY_LENGTH: like C{MAX_LENGTH}, but for 0xff type frames
+    @type MAX_BINARY_LENGTH: C{int}
     @ivar request: C{Request} instance.
     @type request: L{twisted.web.server.Request}
     @ivar handler: L{WebSocketHandler} instance handling the request.
@@ -438,13 +453,14 @@ class WebSocketFrameDecoder(object):
     """
 
     MAX_LENGTH = 16384
-
+    MAX_BINARY_LENGTH = 2147483648
 
     def __init__(self, request, handler):
         self.request = request
         self.handler = handler
         self._data = []
         self._currentFrameLength = 0
+        self._state = "FRAME_START"
 
     def dataReceived(self, data):
         """
@@ -455,35 +471,105 @@ class WebSocketFrameDecoder(object):
         """
         if not data:
             return
-        while True:
-            endIndex = data.find("\xff")
-            if endIndex != -1:
-                self._currentFrameLength += endIndex
-                if self._currentFrameLength > self.MAX_LENGTH:
-                    self.handler.frameLengthExceeded()
-                    break
-                self._currentFrameLength = 0
-                frame = "".join(self._data) + data[:endIndex]
-                self._data[:] = []
-                if frame[0] != "\x00":
-                    self.request.transport.loseConnection()
-                    break
-                self.handler.frameReceived(frame[1:])
-                data = data[endIndex + 1:]
-                if not data:
-                    break
-                if data[0] != "\x00":
-                    self.request.transport.loseConnection()
-                    break
-            else:
-                self._currentFrameLength += len(data)
-                if self._currentFrameLength > self.MAX_LENGTH + 1:
-                    self.handler.frameLengthExceeded()
-                else:
-                    self._data.append(data)
+        self._data.append(data)
+
+        while self._data:
+            try:
+                self.consumeData(self._data[-1])
+            except IncompleteFrame:
+                break
+            except DecodingError:
+                log.err()
+                self.request.transport.loseConnection()
                 break
 
+    def consumeData(self, data):
+        """
+        Process the last data chunk received.
+
+        After processing is done, L{IncompleteFrame} should be raised or
+        L{_addRemainingData} should be called.
+
+        @param data: last chunk of data received.
+        @type data: C{str}
+        """
+    consumeData = makeStatefulDispatcher("consumeData", consumeData)
+
+    def _consumeData_FRAME_START(self, data):
+        self._currentFrameLength = 0
+
+        if data[0] == "\x00":
+            self._state = "PARSING_TEXT_FRAME"
+        elif data[0] == "\xff":
+            self._state = "PARSING_LENGTH"
+        else:
+            raise DecodingError("Invalid frame type 0x%s" %
+                                data[0].encode("hex"))
+
+        self._addRemainingData(data[1:])
+
+    def _consumeData_PARSING_TEXT_FRAME(self, data):
+        endIndex = data.find("\xff")
+        if endIndex == -1:
+            self._currentFrameLength += len(data)
+        else:
+            self._currentFrameLength += endIndex
+
+        self._currentFrameLength += endIndex
+        # check length + 1 to account for the initial frame type byte
+        if self._currentFrameLength + 1 > self.MAX_LENGTH:
+            self.handler.frameLengthExceeded()
+
+        if endIndex == -1:
+            raise IncompleteFrame()
+
+        frame = "".join(self._data[:-1]) + data[:endIndex]
+        self.handler.frameReceived(frame)
+
+        remainingData = data[endIndex + 1:]
+        self._addRemainingData(remainingData)
+
+        self._state = "FRAME_START"
+
+    def _consumeData_PARSING_LENGTH(self, data):
+        current = 0
+        available = len(data)
+
+        while current < available:
+            byte = ord(data[current])
+            length, more = byte & 0x7F, bool(byte & 0x80)
+
+            self._currentFrameLength *= 128
+            self._currentFrameLength += length
+            if self._currentFrameLength > self.MAX_BINARY_LENGTH:
+                self.handler.frameLengthExceeded()
+
+            current += 1
+
+            if not more:
+                remainingData = data[current:]
+                self._addRemainingData(remainingData)
+                self._state = "PARSING_BINARY_FRAME"
+                break
+        else:
+            raise IncompleteFrame()
+
+    def _consumeData_PARSING_BINARY_FRAME(self, data):
+        available = len(data)
+
+        if self._currentFrameLength <= available:
+            remainingData = data[self._currentFrameLength:]
+            self._addRemainingData(remainingData)
+            self._state = "FRAME_START"
+        else:
+            self._currentFrameLength -= available
+            self._data[:] = []
+
+    def _addRemainingData(self, remainingData):
+        if remainingData:
+            self._data[:] = [remainingData]
+        else:
+            self._data[:] = []
 
 
 __all__ = ["WebSocketHandler", "WebSocketSite"]
-

--- a/websocket.py
+++ b/websocket.py
@@ -869,7 +869,13 @@ class WebSocketHybiFrameDecoder(WebSocketFrameDecoder):
         data = "".join(self._data)
         self._maskingKey = struct.unpack(">4B", data[:4])
         self._addRemainingData(data[4:])
-        self._state = "HYBI_PAYLOAD"
+
+        if self._currentFrameLength:
+            self._state = "HYBI_PAYLOAD"
+        else:
+            # there will be no payload, notify the handler of an empty frame
+            # and continue
+            self._frameCompleted("", data[4:])
 
     def _consumeData_HYBI_PAYLOAD(self, data):
         available = len(data)

--- a/websocket.py
+++ b/websocket.py
@@ -337,7 +337,8 @@ class WebSocketRequest(Request):
 
             self.write("\r\n")
             self.channel.setRawMode()
-            self.channel._transferDecoder = WebSocketHybiFrameDecoder(
+            # XXX we probably don't want to set _transferDecoder
+            self.channel._transferDecoder = WebSocketFrameDecoder(
                 self, handler)
             handler.transport._connectionMade()
             return


### PR DESCRIPTION
These changes make txWebSocket support hybi-10, as explained in rlotun/txWebSocket#12

My hybi-10 branch relies on my binary-frames-closing-handshake, because of the makeStatefulDispatcher usage. This pull request incorporates both of these branches, I believe.
